### PR TITLE
Fix multiple Contribute and Contact links

### DIFF
--- a/docs/.vuepress/components/Home/Hero.vue
+++ b/docs/.vuepress/components/Home/Hero.vue
@@ -8,7 +8,7 @@
             <br>
             <a class='second-link' href="/guide/udk/00_start.html">Explore the Documentation</a>
             <br>
-            <a class='first-link' href="/more/contribute">Get Involved</a>
+            <a class='first-link' href="/more/contribute.html">Get Involved</a>
             <br>
             <a class='second-link' href="https://steamcommunity.com/app/252950/workshop/">Browse the Maps</a>
         </h3> 

--- a/docs/cheatsheet/index.md
+++ b/docs/cheatsheet/index.md
@@ -7,7 +7,7 @@ These Cheat Sheets are meant as quick references for tricky topics. I recommend 
 
 ## Ideas?
 
-Anything you would like to see encapsulated as a Cheat Sheet? [Contact us](../more/contact) with your idea, or [Contribute](.../more/contribute) directly!
+Anything you would like to see encapsulated as a Cheat Sheet? [Contact us](/more/contact) with your idea, or [Contribute](/more/contribute) directly!
 
 ## General UDK Tips and Tricks <Badge text="not finished" type="warning"/>
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -10,7 +10,7 @@ This is an attempt at distilling down much of the knowledge that has been shared
 :::warning NOTE
 **This FAQ will cover Mapmaking. It will not cover Bakkesmod Plugins, Decal Mods, RLBots, or anything outside the scope of Mapmaking.**
 :::
-Is an answer incomplete or not up-to-date? Read [this guide](../more/contribute) to learn how you can contribute, or go directly to [GitHub.](https://github.com/RocketLeagueMapmaking/RL-docs/blob/master/CONTRIBUTING.md)
+Is an answer incomplete or not up-to-date? Read [this guide](/more/contribute) to learn how you can contribute, or go directly to [GitHub.](https://github.com/RocketLeagueMapmaking/RL-docs/blob/master/CONTRIBUTING.md)
 
 ## General
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -30,13 +30,13 @@ Resources and communities can seem a bit scattered. The Rocket League Mapmaking 
 
 ## Support You
 
-You'll likely require assistance at some point in your journey. Please check the [FAQ](../faq) or [contact us](../more/contact) for assistance. Join the [Rocket League Mapmaking Discord Server](https://discord.gg/PWu3ZWa) to get connected.
+You'll likely require assistance at some point in your journey. Please check the [FAQ](../faq) or [contact us](/more/contact) for assistance. Join the [Rocket League Mapmaking Discord Server](https://discord.gg/PWu3ZWa) to get connected.
 
 ## Support Us
 
 This website has no advertisements so you can focus on the important stuff. If you want to support us with content, ideas, or simply money for contests, we would greatly appreciate it!
-* [Contribute to this guide](../more/contribute)
-* [Donate (for future contests)](../more/contribute)
+* [Contribute to this guide](/more/contribute)
+* [Donate (for future contests)](/more/contribute)
 
 ## Cheat Sheets
 Portions of these guides have been condensed into brief, single-page references, which may be found in the [Cheat Sheets](../cheatsheet) section. Refer to them when you just need a quick reminder.

--- a/docs/guide/misc/01_misc.md
+++ b/docs/guide/misc/01_misc.md
@@ -7,4 +7,4 @@ title: Miscellaneous
 
 This section is for anything and everything that's not along the critical path of mapmaking. These are the `woah that's cool`'s, the `nice to have`'s, and generally just features that you will not always need.
 
-Anything you would like to see here? [Contact us](../more/contact) with your idea, or [Contribute](.../more/contribute) directly!
+Anything you would like to see here? [Contact us](/more/contact) with your idea, or [Contribute](/more/contribute) directly!

--- a/docs/guide/udk/20_extra_modes.md
+++ b/docs/guide/udk/20_extra_modes.md
@@ -4,7 +4,7 @@ title: Extra Modes
 # UDK Advanced
 
 :::tip
-Do you have experience with extra modes and want to share your knowledge? Check the [contribution guide.](../../more/contribute)
+Do you have experience with extra modes and want to share your knowledge? Check the [contribution guide.](/more/contribute)
 :::
 
 ## Hoops <Badge text="not finished" type="warning"/>


### PR DESCRIPTION
Currently multiple "Contribute" and "Contact" links are broken.
We fix them in this PR by changing them from `../more/cont*` to `/more/cont*`.

I am not sure what the issue is since plenty of other "../" links work
but for some reason the "more" section links don't work with relative paths.

<!-- (Update "[ ]" to "[x]" to check a box) -->

**Please describe the changes this PR makes and why it should be merged:**

Multiple pages have broken links to the "Contact" and "Contribute" pages. This PR adjusts the links to be absolute paths instead of relative to make the links work.

Example pages with broken links:

- "Get involved" on https://rocketleaguemapmaking.com/
- "Contact" and "Contribute" on https://rocketleaguemapmaking.com/cheatsheet/
- "this guide" on https://rocketleaguemapmaking.com/faq/
- Multiple on https://rocketleaguemapmaking.com/guide/
- "Contact" and "Contribute" on https://rocketleaguemapmaking.com/guide/misc/01_misc.html
- "Contribution guide" on https://rocketleaguemapmaking.com/guide/udk/20_extra_modes.html

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Documentation changes

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Code changes have been tested locally, or there are no code changes
- [x] I have followed the steps to contribute and followed the guidelines (can be found [on the website](https://rocketleaguemapmaking.com/more/contribute.html#add-new-content) or [github](https://github.com/RocketLeagueMapmaking/RL-docs/blob/master/CONTRIBUTING.md))
- [x] I know how to update typings and have done so, or typings don't need updating

**Other information**
