### PR TITLE
feat: add legal documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ The certificate is renewed by the [`renewcert`](.github/workflows/certificate.ym
 [package.json]: https://github.com/RocketLeagueMapmaking/RL-docs/blob/master/package.json
 [github-actions]: https://github.com/RocketLeagueMapmaking/RL-docs/actions
 [domain]: https://rocketleaguemapmaking.com
-[dev-domain]: https://rocketleaguemapmaking.pages.dev
+[dev-domain]: https://dev.rocketleaguemapmaking.com

--- a/docs/.vitepress/config/data/config.json
+++ b/docs/.vitepress/config/data/config.json
@@ -4,7 +4,7 @@
     "editLinkText": "Edit this page",
     "footer": {
         "message": "Rocket League map making guide",
-        "copyright": "Made by <a href=\"/more/about\">Mr. Swaggles</a>"
+        "copyright": "Made by <a href=\"/more/about\">Mr. Swaggles</a><br><a href=\"/privacy\">Privacy policy</a> | <a href=\"/tos\">Terms of Service</a>"
     },
     "socialLinks": [
         {

--- a/docs/.vitepress/config/head.ts
+++ b/docs/.vitepress/config/head.ts
@@ -46,6 +46,13 @@ export default <HeadConfig[]>[
         {},
         `const ${getCollectionItemEditLink.name} = ${getCollectionItemEditLink}`
     ],
+    ['script',
+        {
+            defer: '',
+            src: 'https://static.cloudflareinsights.com/beacon.min.js',
+            'data-cf-beacon': '{"token": "f333ed2ade344138a71c7882e02e1b1b"}',
+        }
+    ],
 
     // OG links
     // Not including the special Twitter links, because X...

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,4 +1,5 @@
 ---
+title: Privacy policy
 lastUpdated: true
 sidebar: false
 next: false

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,49 @@
+---
+lastUpdated: true
+sidebar: false
+next: false
+---
+
+# Privacy policy
+
+Rocket League Map Making ("we," "us," or "our") values your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website or use our services. Please read this policy carefully. If you do not agree with the terms of this Privacy Policy, please do not use our website.
+
+For its subservices, including and not limited to, see their respective privacy policy:
+
+- [Rocket League Map Making Analytics](https://analytics.rocketleaguemapmaking.com/privacy)
+- [SwagBot](https://swagbot.rocketleaguemapmaking.com/privacy)
+
+If you choose to use this service, then you agree with the collection of data as described in this privacy policy.
+Your data will never be shared and will not be used other for the purposes described in this policy. It is only accessible by the maintainers of this service.
+
+## Website
+
+This website uses no third-party items. This website tracks your usage anonymously using [Cloudflare Web analytics](https://www.cloudflare.com/web-analytics/). The cookies are used for user configuration and only used on device.
+
+Search results are stored anonymously to review and improve the content of the guide. By using the search functionality you agree that your query will be stored.
+
+### Patreon
+
+For the Patreon shoutout the members of the Patreon are displayed using their profile details made available in their public Web API.
+
+### Steam
+
+The Steam integrations only uses the data available in their public Web API.
+
+### Third-Party Links
+
+Our website may contain links to third-party websites. We are not responsible for the privacy practices of these external sites. We encourage you to review their privacy policies.
+
+## Data removal
+
+Since no user specific information is collected, it is not possible to remove data related to you.
+If this service is being misused the maintainers can at any time remove the user from this service (unnoticed).
+
+## Changes to This Privacy Policy
+
+We may update this Privacy Policy from time to time. We will notify you of significant changes by posting the new policy on our website with the updated effective date.
+
+## Contact us
+
+If you have any questions or concerns about this Privacy Policy, please contact us at:
+Email: privacy@rocketleaguemapmaking.com

--- a/docs/tos.md
+++ b/docs/tos.md
@@ -1,4 +1,5 @@
 ---
+title: Terms of Service
 lastUpdated: true
 sidebar: false
 next: false

--- a/docs/tos.md
+++ b/docs/tos.md
@@ -1,0 +1,20 @@
+---
+lastUpdated: true
+sidebar: false
+next: false
+---
+
+# Terms of Service
+
+By using this service you agree with the terms of service as described in this document.
+This service is provided as is and is not responsible for any damage caused by the use of this service.
+This service is not affiliated with Rocket League, Epic Games, Discord and Steam.
+
+By using this service or subservices of this service, such as [Swagbot](https://swagbot.rocketleaguemapmaking.com) or [Analytics](https://analytics.rocketleaguemapmaking.com), you agree that you have read, understood, and accepted these terms.
+You are also responsible for informing the members in your discord server about these terms.
+If you do not agree with any of these terms, you are prohibited from using this service.
+
+## Terms of use
+
+- You will not use this or subservices of this service to create content which harasses any user in any way
+- You will not use this or products of this service in violation of any part of the Rocket League TOS


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

For the analytics project, Epic Games requires a TOS and privacy policy, but that can't be hosted on a subdomain. This is a workaround to create those documents on the rlmm domain and link to the subservices maintained by this GitHub org.

Also adds a simple beacon to have metrics on how the site is used

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation changes
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Code changes have been tested locally, or there are no code changes
- [ ] I have followed [the steps to contribute](https://github.com/RocketLeagueMapmaking/RL-docs/blob/master/CONTRIBUTING.md) and followed the guidelines
- [ ] If my contribution contains a workflow, I've performed said workflow directly before making the change request and no steps are missing.

**Other information**
